### PR TITLE
update/goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ snapshot:
 
 changelog:
   skip: false
-  sort: ""
+  use: github-native
   filters:
     exclude:
     - '^Bump'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
     - darwin
     goarch:
     - amd64
+    - arm64
     main: ./cmd/termshot/main.go
     flags:
     - -tags

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,8 +10,6 @@ builds:
     - arm64
     main: ./cmd/termshot/main.go
     flags:
-    - -tags
-    - netgo
     - -trimpath
     ldflags:
     - -s -w -extldflags "-static" -X github.com/homeport/termshot/internal/cmd.version={{.Version}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,8 +30,7 @@ changelog:
   sort: ""
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+    - '^Bump'
 
 brews:
   - tap:


### PR DESCRIPTION
- Add `arm64` to the list of architectures
- Remove obsolete `netgo` build tag
- Ignore dependency bumps in change log
- Use `github-native` changelog generation
