### PR TITLE
Tweak Ginkgo install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,5 +30,5 @@ jobs:
 
     - name: Test
       run: |
-        go install github.com/onsi/ginkgo/v2/ginkgo
+        go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
         make test


### PR DESCRIPTION
Add `-mod=mod` to hopefully get rid of `go.sum` issues.
