### PR TITLE
Fix GoReleaser brew tap warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ changelog:
     - '^Bump'
 
 brews:
-  - tap:
+  - repository:
       owner: homeport
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
Ref: https://goreleaser.com/deprecations/#brewstap

Replace `tap` with `repository`.