### PR TITLE
Specify that homebrew works on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For example, `termshot --show-cmd -- lolcat -f <(figlet -f big foobar)` will cre
 
 ## Installation
 
-### macOS
+### macOS / Linux
 
 Use `homebrew` to install `termshot`: `brew install homeport/tap/termshot`
 


### PR DESCRIPTION
The [formula supports Linux](https://github.com/homeport/homebrew-tap/blob/master/HomebrewFormula/termshot.rb#L30) so I made that clear using brew to install on Linux is an option.