### PR TITLE
Start pseudo terminal with explicit window size

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -73,12 +73,14 @@ window including all terminal colors and text decorations.
 
 		var scaffold = img.NewImageCreator()
 		var buf bytes.Buffer
+		var pt = ptexec.New()
 
 		// Initialise scaffold with a column sizing so that the
 		// content can be wrapped accordingly
 		//
 		if columns, err := cmd.Flags().GetInt("columns"); err == nil && columns > 0 {
 			scaffold.SetColumns(columns)
+			pt.Cols(uint16(columns))
 		}
 
 		// Disable window shadow if requested
@@ -110,9 +112,9 @@ window including all terminal colors and text decorations.
 		// Run the provided command in a pseudo terminal and capture
 		// the output to be later rendered into the screenshot
 		//
-		bytes, err := ptexec.RunCommandInPseudoTerminal(args[0], args[1:]...)
+		bytes, err := pt.Command(args[0], args[1:]...).Run()
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to run command in pseudo terminal: %w", err)
 		}
 		buf.Write(bytes)
 
@@ -135,7 +137,7 @@ window including all terminal colors and text decorations.
 				editor = "vi"
 			}
 
-			if _, err := ptexec.RunCommandInPseudoTerminal(editor, tmpFile.Name()); err != nil {
+			if _, err := ptexec.New().Command(editor, tmpFile.Name()).Run(); err != nil {
 				return err
 			}
 

--- a/internal/ptexec/exec_test.go
+++ b/internal/ptexec/exec_test.go
@@ -1,0 +1,56 @@
+// Copyright © 2025 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ptexec_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/homeport/termshot/internal/ptexec"
+)
+
+var _ = Describe("Pseudo Terminal Execute Suite", func() {
+	Context("running commands in pseudo terminal", func() {
+		It("should run a command just fine", func() {
+			out, err := New().Stdout(GinkgoWriter).
+				Command("echo", "hello").
+				Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(trimmed(out)).To(Equal("hello"))
+		})
+
+		It("should run a script just fine", func() {
+			out, err := New().Stdout(GinkgoWriter).
+				Command("echo hello").
+				Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(trimmed(out)).To(Equal("hello"))
+		})
+
+		It("should run with fixed terminal size", func() {
+			out, err := New().Stdout(GinkgoWriter).Cols(40).Rows(12).Command("stty", "size").Run()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(trimmed(out)).To(Equal("12 40"))
+		})
+	})
+})

--- a/internal/ptexec/ptexec_suite_test.go
+++ b/internal/ptexec/ptexec_suite_test.go
@@ -1,0 +1,38 @@
+// Copyright © 2025 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ptexec_test
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPtexec(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pseudo Terminal Exec Suite")
+}
+
+func trimmed(in []byte) string {
+	return strings.TrimSpace(string(in))
+}


### PR DESCRIPTION
Ref: https://github.com/homeport/termshot/issues/254

Make sure to start pseudo terminal with fixed size in case the columns
flag was used.

Refactor `ptexec` package to allow for more flexibility.

Introduce test cases for `ptexec` package.
