### PR TITLE
Add flags to write and read raw content

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ termshot --edit -- "ls -a"
 
 ### Miscellaneous flags
 
+#### `--raw-write <file>`
+
+Write command output as-is into the file that is specified as the flag argument. No screenshot is being created. The command-line flag `--filename` has no effect, when `--raw-write` is used.
+
+#### `--raw-read <file>`
+
+Read input from provided file instead of running a command. If this flag is being used, no pseudo terminal is being created to execute a command. The command-line flags `--show-cmd`, and `--edit` have no effect, when `--raw-read` is used.
+
 #### `--version`/`-v`
 
 Print the version of `termshot` installed.

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/homeport/termshot
 
 go 1.23.0
 
-toolchain go1.24.1
-
 require (
 	github.com/creack/pty v1.1.24
 	github.com/esimov/stackblur-go v1.1.0

--- a/internal/img/img_suite_test.go
+++ b/internal/img/img_suite_test.go
@@ -56,7 +56,7 @@ func (m *LookLikeMatcher) Match(actual interface{}) (bool, error) {
 	}
 
 	var out bytes.Buffer
-	if err := scaffold.Write(&out); err != nil {
+	if err := scaffold.WritePNG(&out); err != nil {
 		return false, err
 	}
 

--- a/internal/img/output.go
+++ b/internal/img/output.go
@@ -380,7 +380,15 @@ func (s *Scaffold) image() (image.Image, error) {
 	return dc.Image(), nil
 }
 
+// Write writes the scaffold content as PNG into the provided writer
+//
+// Deprecated: Use [Scaffold.WritePNG] instead.
 func (s *Scaffold) Write(w io.Writer) error {
+	return s.WritePNG(w)
+}
+
+// WritePNG writes the scaffold content as PNG into the provided writer
+func (s *Scaffold) WritePNG(w io.Writer) error {
 	img, err := s.image()
 	if err != nil {
 		return err
@@ -424,4 +432,10 @@ func (s *Scaffold) Write(w io.Writer) error {
 	}
 
 	return png.Encode(w, img)
+}
+
+// WriteRaw writes the scaffold content as-is into the provided writer
+func (s *Scaffold) WriteRaw(w io.Writer) error {
+	_, err := w.Write([]byte(s.content.String()))
+	return err
 }

--- a/internal/img/output_test.go
+++ b/internal/img/output_test.go
@@ -96,4 +96,20 @@ var _ = Describe("Creating images", func() {
 			Expect(scaffold).To(LookLike(testdata("expected-ansi.png")))
 		})
 	})
+
+	Context("Use scaffold to create raw output file", func() {
+		var buf bytes.Buffer
+
+		BeforeEach(func() {
+			SetColorSettings(ON, ON)
+			buf.Reset()
+		})
+
+		It("should write an output file with the content as-is", func() {
+			scaffold := NewImageCreator()
+			Expect(scaffold.AddContent(strings.NewReader(Sprintf("MintCream{foobar}")))).To(Succeed())
+			Expect(scaffold.WriteRaw(&buf)).To(Succeed())
+			Expect(buf.String()).To(Equal("\x1b[38;2;245;255;250mfoobar\x1b[0m"))
+		})
+	})
 })


### PR DESCRIPTION
Ref: https://github.com/homeport/termshot/issues/176

Add flag to write output as-is (raw) into a file rather than creating a
screenshot from the output.

Add flag to read raw content from a file rather than running a command to
obtain the output from the command execution.
