### PR TITLE
Use `scaffold.WritePNG` instead of `scaffold.Write`

### DIFF
--- a/internal/cmd/root_darwin.go
+++ b/internal/cmd/root_darwin.go
@@ -54,7 +54,7 @@ func init() {
 				return err
 			}
 
-			if err := scaffold.Write(hex.NewEncoder(&buf)); err != nil {
+			if err := scaffold.WritePNG(hex.NewEncoder(&buf)); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Use `scaffold.WritePNG` instead of `scaffold.Write` in clipboard code.
