### PR TITLE
Bump to `golangci-lint` config version 2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,6 +26,6 @@ jobs:
         go-version: stable
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
         only-new-issues: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 ---
+version: "2"
 linters:
   enable:
-  - gosec
-  - gocritic
+    - gocritic
+    - gosec

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -60,6 +60,7 @@ window including all terminal colors and text decorations.
 			}
 
 			// #nosec G104
+			// nolint:all
 			bunt.Printf("Lime{*%s*} version DimGray{%s}\n",
 				executableName(),
 				version,
@@ -142,7 +143,7 @@ window including all terminal colors and text decorations.
 				return tmpErr
 			}
 
-			defer os.Remove(tmpFile.Name())
+			defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 			if err := os.WriteFile(tmpFile.Name(), buf.Bytes(), os.FileMode(0644)); err != nil {
 				return err
@@ -216,7 +217,7 @@ window including all terminal colors and text decorations.
 			return fmt.Errorf("failed to create file: %w", err)
 		}
 
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 		return scaffold.WritePNG(file)
 	},
 }

--- a/internal/img/output.go
+++ b/internal/img/output.go
@@ -305,7 +305,7 @@ func (s *Scaffold) image() (image.Image, error) {
 
 	// Apply the actual text into the prepared content area of the window
 	//
-	var x, y float64 = xOffset + paddingX, yOffset + paddingY + titleOffset + s.fontHeight()
+	var x, y = xOffset + paddingX, yOffset + paddingY + titleOffset + s.fontHeight()
 	for _, cr := range s.content {
 		switch cr.Settings & 0x1C {
 		case 4:
@@ -398,8 +398,8 @@ func (s *Scaffold) WritePNG(w io.Writer) error {
 	//
 	if s.clipCanvas {
 		if imgRGBA, ok := img.(*image.RGBA); ok {
-			var minX, minY int = math.MaxInt, math.MaxInt
-			var maxX, maxY int = 0, 0
+			var minX, minY = math.MaxInt, math.MaxInt
+			var maxX, maxY = 0, 0
 
 			var bounds = imgRGBA.Bounds()
 			for x := bounds.Min.X; x < bounds.Max.X; x++ {

--- a/internal/ptexec/exec.go
+++ b/internal/ptexec/exec.go
@@ -145,7 +145,7 @@ func (c *PseudoTerminal) Run() ([]byte, error) {
 	}
 
 	go func() {
-		defer pt.Close()
+		defer func() { _ = pt.Close() }()
 		_, copyErr := io.Copy(pt, os.Stdin)
 		if copyErr != nil {
 			errors = append(errors, copyErr)


### PR DESCRIPTION
Migrate `.golangci.yaml` to version 2.

Address `golangci-lint` findings.
