### PR TITLE
feat(font): add mac-os system font fallback chain to reduce tofu on missing glyphs

### DIFF
--- a/internal/img/fallback.go
+++ b/internal/img/fallback.go
@@ -1,0 +1,128 @@
+// Copyright © 2020 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package img
+
+import (
+	"image"
+
+	"golang.org/x/image/font"
+	"golang.org/x/image/math/fixed"
+)
+
+// glyphPresence is implemented by faces backed by a *truetype.Font.
+// It gives an authoritative answer about whether a rune is in the font's
+// cmap, which the font.Face ok returns cannot — truetype faces return ok=true
+// even for missing runes because they succeed in rasterizing glyph 0 (.notdef).
+type glyphPresence interface {
+	hasGlyph(r rune) bool
+}
+
+// FallbackFace wraps a primary font.Face with a slice of fallback faces.
+//
+// If the primary implements glyphPresence, it is checked first; glyphs
+// present in the primary are rendered by the primary, and only missing glyphs
+// fall through to the fallback list (then to primary's .notdef tofu).
+//
+// If the primary does not implement glyphPresence, it is used directly for
+// all glyphs (no fallback is consulted), preserving pre-fallback behavior.
+type FallbackFace struct {
+	primary   font.Face
+	fallbacks []font.Face
+}
+
+func NewFallbackFace(primary font.Face, fallbacks ...font.Face) *FallbackFace {
+	return &FallbackFace{primary: primary, fallbacks: fallbacks}
+}
+
+func (f *FallbackFace) Close() error {
+	for _, fb := range f.fallbacks {
+		fb.Close()
+	}
+	return f.primary.Close()
+}
+
+func (f *FallbackFace) Glyph(dot fixed.Point26_6, r rune) (dr image.Rectangle, mask image.Image, maskp image.Point, advance fixed.Int26_6, ok bool) {
+	if gp, isGP := f.primary.(glyphPresence); isGP {
+		if gp.hasGlyph(r) {
+			return f.primary.Glyph(dot, r)
+		}
+		for _, fb := range f.fallbacks {
+			if gp2, isGP2 := fb.(glyphPresence); isGP2 && !gp2.hasGlyph(r) {
+				continue
+			}
+			if dr, mask, maskp, advance, ok = fb.Glyph(dot, r); ok {
+				return
+			}
+		}
+		dr, mask, maskp, advance, ok = f.primary.Glyph(dot, r)
+		return
+	}
+	dr, mask, maskp, advance, ok = f.primary.Glyph(dot, r)
+	return
+}
+
+func (f *FallbackFace) GlyphBounds(r rune) (bounds fixed.Rectangle26_6, advance fixed.Int26_6, ok bool) {
+	if gp, isGP := f.primary.(glyphPresence); isGP {
+		if gp.hasGlyph(r) {
+			return f.primary.GlyphBounds(r)
+		}
+		for _, fb := range f.fallbacks {
+			if gp2, isGP2 := fb.(glyphPresence); isGP2 && !gp2.hasGlyph(r) {
+				continue
+			}
+			if bounds, advance, ok = fb.GlyphBounds(r); ok {
+				return
+			}
+		}
+		bounds, advance, ok = f.primary.GlyphBounds(r)
+		return
+	}
+	bounds, advance, ok = f.primary.GlyphBounds(r)
+	return
+}
+
+func (f *FallbackFace) GlyphAdvance(r rune) (advance fixed.Int26_6, ok bool) {
+	if gp, isGP := f.primary.(glyphPresence); isGP {
+		if gp.hasGlyph(r) {
+			return f.primary.GlyphAdvance(r)
+		}
+		for _, fb := range f.fallbacks {
+			if gp2, isGP2 := fb.(glyphPresence); isGP2 && !gp2.hasGlyph(r) {
+				continue
+			}
+			if advance, ok = fb.GlyphAdvance(r); ok {
+				return
+			}
+		}
+		advance, ok = f.primary.GlyphAdvance(r)
+		return
+	}
+	advance, ok = f.primary.GlyphAdvance(r)
+	return
+}
+
+func (f *FallbackFace) Kern(r0, r1 rune) fixed.Int26_6 {
+	return f.primary.Kern(r0, r1)
+}
+
+func (f *FallbackFace) Metrics() font.Metrics {
+	return f.primary.Metrics()
+}

--- a/internal/img/output.go
+++ b/internal/img/output.go
@@ -97,6 +97,8 @@ func NewImageCreator() Scaffold {
 		DPI:  defaultFontDPI,
 	}
 
+	fallbacks := loadSystemFallbacks(fontFaceOptions)
+
 	return Scaffold{
 		defaultForegroundColor: bunt.LightGray,
 
@@ -113,10 +115,10 @@ func NewImageCreator() Scaffold {
 		shadowOffsetX:   f * 16,
 		shadowOffsetY:   f * 16,
 
-		regular:    font.Hack.Regular(fontFaceOptions),
-		bold:       font.Hack.Bold(fontFaceOptions),
-		italic:     font.Hack.Italic(fontFaceOptions),
-		boldItalic: font.Hack.BoldItalic(fontFaceOptions),
+		regular:    NewFallbackFace(loadHackPrimary("Hack-Regular.ttf", fontFaceOptions, font.Hack.Regular(fontFaceOptions)), fallbacks...),
+		bold:       NewFallbackFace(loadHackPrimary("Hack-Bold.ttf", fontFaceOptions, font.Hack.Bold(fontFaceOptions)), fallbacks...),
+		italic:     NewFallbackFace(loadHackPrimary("Hack-Italic.ttf", fontFaceOptions, font.Hack.Italic(fontFaceOptions)), fallbacks...),
+		boldItalic: NewFallbackFace(loadHackPrimary("Hack-BoldItalic.ttf", fontFaceOptions, font.Hack.BoldItalic(fontFaceOptions)), fallbacks...),
 
 		lineSpacing: 1.2,
 		tabSpaces:   2,

--- a/internal/img/sysfonts_darwin.go
+++ b/internal/img/sysfonts_darwin.go
@@ -1,0 +1,90 @@
+// Copyright © 2020 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package img
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/golang/freetype/truetype"
+	imgfont "golang.org/x/image/font"
+)
+
+// indexedFace wraps a truetype font.Face and its underlying *truetype.Font so
+// that hasGlyph can use Font.Index(r) != 0 — the correct glyph-presence test
+// — rather than the face's ok return, which is true even for .notdef glyphs.
+type indexedFace struct {
+	imgfont.Face
+	f *truetype.Font
+}
+
+func (t *indexedFace) hasGlyph(r rune) bool {
+	return t.f.Index(r) != 0
+}
+
+// loadHackPrimary returns an *indexedFace for the given Hack TTF file found in
+// ~/Library/Fonts, enabling correct glyph-presence detection for fallback
+// dispatch. Falls back to the provided face if the file is absent or invalid.
+func loadHackPrimary(filename string, opts *truetype.Options, fallback imgfont.Face) imgfont.Face {
+	home, _ := os.UserHomeDir()
+	data, err := os.ReadFile(filepath.Join(home, "Library/Fonts", filename))
+	if err != nil {
+		return fallback
+	}
+	f, err := truetype.Parse(data)
+	if err != nil {
+		return fallback
+	}
+	return &indexedFace{Face: truetype.NewFace(f, opts), f: f}
+}
+
+var systemFontPaths = []string{
+	"/System/Library/Fonts/Apple Symbols.ttf",
+	"/System/Library/Fonts/Apple Braille.ttf",
+}
+
+// loadSystemFallbacks loads supplementary system fonts as indexed fallback
+// faces. Silently skips any that cannot be read or parsed.
+func loadSystemFallbacks(opts *truetype.Options) []imgfont.Face {
+	home, _ := os.UserHomeDir()
+
+	paths := append(
+		systemFontPaths,
+		filepath.Join(home, "Library/Fonts/SymbolsNerdFont-Regular.ttf"),
+	)
+
+	var faces []imgfont.Face
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		f, err := truetype.Parse(data)
+		if err != nil {
+			continue
+		}
+		faces = append(faces, &indexedFace{
+			Face: truetype.NewFace(f, opts),
+			f:    f,
+		})
+	}
+	return faces
+}

--- a/internal/img/sysfonts_other.go
+++ b/internal/img/sysfonts_other.go
@@ -1,0 +1,36 @@
+// Copyright © 2020 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build !darwin
+
+package img
+
+import (
+	"github.com/golang/freetype/truetype"
+	imgfont "golang.org/x/image/font"
+)
+
+func loadHackPrimary(_ string, _ *truetype.Options, fallback imgfont.Face) imgfont.Face {
+	return fallback
+}
+
+func loadSystemFallbacks(_ *truetype.Options) []imgfont.Face {
+	return nil
+}


### PR DESCRIPTION
**TL;DR:** If you use a character that `Hack` doesn't support, you get _tofu_ instead of an error. 
This can be confusing because your terminal might try to "help" by pulling in glyphs from other fonts to fill the gap, making the termshot output look inconsistent.

So while the user see's something like:
<img width="2600" height="828" alt="user_sees" src="https://github.com/user-attachments/assets/d9aeae49-f107-4210-887e-ed496c2f89f3" />

The rendered result might look like:
<img width="2600" height="828" alt="render_looks_like" src="https://github.com/user-attachments/assets/2a6299ca-0cec-4d9a-88a3-1c25a2699d07" />

---

This is probably due to `github.com/golang/freetype/truetype faces` returning `ok=true` from `Glyph`, `GlyphBounds`, and `GlyphAdvance` even when a rune is absent from the font. 

The Missing runes map to glyph index 0 (.notdef), and .notdef rasterizes successfully, so the face reports _success_ while drawing _tofu_.   Just checking `ok` cannot distinguish between "font has this glyph" from "font drew its missing-glyph box."

> [!note]
> I threw together a workaround that _worksonmymachine™_ , but you wouldn't want to merge this as is.  
> - This pr is loading `SymbolsNerdFont` from my system, which you wouldn't want to do
> - `Hack` is loaded from ~/Library/Fonts/Hack-*.ttf  (so that its cmap is queryable).   If the files are absent, loadHackPrimary returns the embedded face unchanged and fallback dispatch is silently disabled.
>


## Changelist

This adds a FallbackFace type that wraps the primary font and adds a list of backup fonts, trying each one in order until it finds a font that actually has the character.

callout:
-I'm using `is truetype.Font.Index(r) != 0`, which queries the font's cmap directly. 
Both the primary (Hack) and each fallback are wrapped in an  indexedFace that exposes this via a glyphPresence interface. 

Dispatch then follows: check primary → if missing, check fallbacks in order → fall through to  primary's .notdef.

  - I used `Apple Symbols`, `Apple Braille`, and `SymbolsNerdFont` (because it was late and I just wanted to make it work) as the backups.  On other platforms, the behavior is unchanged.
  - On Linux/CI, all new code is a no-op; behavior is identical to before
  - No new dependencies, no new CLI flags

---

Example test output:

```bash
termshot -f "out.png" -- bash -c "
  termshot -v \
  echo \"braille:   ⠿ ⠙ ⣿ ⡿ ⣿\"
  echo \"geometric: ⬚ ⊡ ◈ ⊹ ⬥ ▨ ▢ ▣\"
  echo \"math:      ∘ ⋰ ※ ∙\"
  echo \"nerd font:   \"
"
```

| production `termshot` 0.6.1  | pr version |
| ------------- | ------------- |
| <img width="1039" height="598" alt="0 6 1" src="https://github.com/user-attachments/assets/c36eda89-1719-4cd3-8b62-13ab9276ff50" />  | <img width="1155" height="598" alt="my-local-dev" src="https://github.com/user-attachments/assets/10ce67a5-4157-44dd-a959-c5dc376a7e75" /> |

---

I did a quick search in the github issues, but didn't immediately see anything that looked like this was a known bug.  
Figured I'd push what I had on the off chance that it helps someone else or results in some useful discussion.

Thanks for making `termshot` available to the community!